### PR TITLE
Fix the Ripple address validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "webpack": "webpack"
   },
   "dependencies": {
+    "base-x": "^1.0.4",
     "biggystring": "^3.0.0",
     "jsonschema": "^1.1.1",
     "edge-ripple-lib": "^1.0.0-beta.1",

--- a/src/indexRipple.js
+++ b/src/indexRipple.js
@@ -15,11 +15,16 @@ import type {
   EdgeWalletInfo
 } from 'edge-core-js'
 import { parse, serialize } from 'uri-js'
+import baseX from 'base-x'
 import { bns } from 'biggystring'
 import { RippleAPI } from 'edge-ripple-lib'
 import keypairs from 'edge-ripple-keypairs'
 
 // import { CurrencyInfoScheme } from './xrpSchema.js'
+
+const base58Codec = baseX(
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+)
 
 let io
 
@@ -38,18 +43,15 @@ function getParameterByName (param, url) {
   return decodeURIComponent(results[2].replace(/\+/g, ' '))
 }
 
-function checkAddress (address: string) {
-  // Ripple doesn't have a simple checkAddress routine so we'll validate by
-  let valid: boolean
-  if (address.slice(0, 1) !== 'r') {
-    valid = false
-  } else if (address.length !== 34) {
-    valid = false
-  } else {
-    // Check that the address only contains characters in the ripple base58 alphabet
-    valid = /^[rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz]+$/.test(address)
+function checkAddress (address: string): boolean {
+  let data: Uint8Array
+  try {
+    data = base58Codec.decode(address)
+  } catch (e) {
+    return false
   }
-  return valid
+
+  return data.length === 25 && address.charAt(0) === 'r'
 }
 
 export const rippleCurrencyPluginFactory: EdgeCurrencyPluginFactory = {

--- a/test/plugin/fixtures.json
+++ b/test/plugin/fixtures.json
@@ -25,6 +25,7 @@
     },
     "encodeUri": {
       "address only": [{"publicAddress": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"}, "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"],
+      "weird address": [{"publicAddress": "rmUSRn9LEnaHztzm13ZGAeAvy48A4r7u9"}, "rmUSRn9LEnaHztzm13ZGAeAvy48A4r7u9"],
       "invalid address": [{"publicAddress": "rf1GeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"}, {"publicAddress": "sf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"}, {"publicAddress": "rf1BiGeXwwQol8Z2ueFYTEXSwuJYfV2Jpn"}],
       "address & amount": [{
         "publicAddress": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",

--- a/test/plugin/plugin.js
+++ b/test/plugin/plugin.js
@@ -256,6 +256,12 @@ for (const fixture of fixtures) {
       )
       assert.equal(encodedUri, fixture['encodeUri']['address only'][1])
     })
+    it('weird address', function () {
+      const encodedUri = plugin.encodeUri(
+        fixture['encodeUri']['weird address'][0]
+      )
+      assert.equal(encodedUri, fixture['encodeUri']['weird address'][1])
+    })
     it('invalid address 0', function () {
       assert.throws(() => {
         plugin.encodeUri(fixture['encodeUri']['invalid address'][0])


### PR DESCRIPTION
We need to use full base58 validation, or we will get this wrong. Before, we were rejecting otherwise valid addresses because the encoded length was randomly shorter.