### PR TITLE
Add support for parsing https://ripple.com//send?to= URIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,11 @@
   "dependencies": {
     "base-x": "^1.0.4",
     "biggystring": "^3.0.0",
-    "jsonschema": "^1.1.1",
     "edge-ripple-lib": "^1.0.0-beta.1",
+    "jsonschema": "^1.1.1",
     "sprintf-js": "^1.1.1",
-    "uri-js": "^3.0.2"
+    "uri-js": "^3.0.2",
+    "url-parse": "^1.4.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/test/plugin/fixtures.json
+++ b/test/plugin/fixtures.json
@@ -21,7 +21,17 @@
       "uri address with unique identifier": ["ripple:rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn?tag=123456789", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "123456789", "XRP"],
       "uri address with amount & label": ["ripple:rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn?amount=1234.56789&label=Johnny%20Ripple", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "1234567890", "XRP", "Johnny Ripple"],
       "uri address with amount, label & message": ["ripple:rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn?amount=1234.56789&label=Johnny%20Ripple&message=Hello%20World,%20I%20miss%20you%20!", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "1234567890", "XRP", "Johnny Ripple", "Hello World, I miss you !"],
-      "uri address with unsupported param": ["ripple:rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn?unsupported=helloworld&amount=12345.6789", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "12345678900", "XRP"]
+      "uri address with unsupported param": ["ripple:rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn?unsupported=helloworld&amount=12345.6789", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "12345678900", "XRP"],
+      "ripple.com invalid uri handler": ["ripples://ripple.co//send?to=rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"],
+      "ripple.com invalid uri domain": ["https://ripple.co//send?to=rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"],
+      "ripple.com invalid uri path": ["https://ripple.co//sends?to=rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"],
+      "ripple.com invalid uri param": ["https://ripple.co//sends?tos=rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"],
+      "ripple.com uri address": ["https://ripple.com//send?to=rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"],
+      "ripple.com uri address with amount": ["https://ripple.com//send?to=rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn&amount=12345.6789", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "12345678900", "XRP"],
+      "ripple.com uri address with unique identifier": ["https://ripple.com//send?to=rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn&tag=123456789", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "123456789", "XRP"],
+      "ripple.com uri address with amount & label": ["https://ripple.com//send?to=rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn&amount=1234.56789&label=Johnny%20Ripple", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "1234567890", "XRP", "Johnny Ripple"],
+      "ripple.com uri address with amount, label & message": ["https://ripple.com//send?to=rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn&amount=1234.56789&label=Johnny%20Ripple&message=Hello%20World,%20I%20miss%20you%20!", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "1234567890", "XRP", "Johnny Ripple", "Hello World, I miss you !"],
+      "ripple.com uri address with unsupported param": ["https://ripple.com//send?to=rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn&unsupported=helloworld&amount=12345.6789", "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "12345678900", "XRP"]
     },
     "encodeUri": {
       "address only": [{"publicAddress": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"}, "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"],

--- a/test/plugin/plugin.js
+++ b/test/plugin/plugin.js
@@ -240,6 +240,125 @@ for (const fixture of fixtures) {
         fixture['parseUri']['uri address with amount & label'][3]
       )
     })
+
+    it('ripple.com invalid URIs', function () {
+      assert.throws(() => {
+        plugin.parseUri(fixture['parseUri']['ripple.com invalid uri handler'][0])
+      })
+      assert.throws(() => {
+        plugin.parseUri(fixture['parseUri']['ripple.com invalid uri domain'][0])
+      })
+      assert.throws(() => {
+        plugin.parseUri(fixture['parseUri']['ripple.com invalid uri path'][0])
+      })
+      assert.throws(() => {
+        plugin.parseUri(fixture['parseUri']['ripple.com invalid uri param'][0])
+      })
+    })
+
+    // Ripple.com valid URIs
+    it('ripple.com uri address', function () {
+      const parsedUri = plugin.parseUri(fixture['parseUri']['ripple.com uri address'][0])
+      assert.equal(
+        parsedUri.publicAddress,
+        fixture['parseUri']['uri address'][1]
+      )
+      assert.equal(parsedUri.nativeAmount, undefined)
+      assert.equal(parsedUri.currencyCode, undefined)
+    })
+    it('ripple.com uri address with amount', function () {
+      const parsedUri = plugin.parseUri(
+        fixture['parseUri']['ripple.com uri address with amount'][0]
+      )
+      assert.equal(
+        parsedUri.publicAddress,
+        fixture['parseUri']['ripple.com uri address with amount'][1]
+      )
+      assert.equal(
+        parsedUri.nativeAmount,
+        fixture['parseUri']['ripple.com uri address with amount'][2]
+      )
+      assert.equal(
+        parsedUri.currencyCode,
+        fixture['parseUri']['ripple.com uri address with amount'][3]
+      )
+    })
+    it('ripple.com uri address with unique identifier', function () {
+      const parsedUri = plugin.parseUri(
+        fixture['parseUri']['ripple.com uri address with unique identifier'][0]
+      )
+      assert.equal(
+        parsedUri.publicAddress,
+        fixture['parseUri']['ripple.com uri address with unique identifier'][1]
+      )
+      assert.equal(
+        parsedUri.uniqueIdentifier,
+        fixture['parseUri']['ripple.com uri address with unique identifier'][2]
+      )
+    })
+    it('ripple.com uri address with amount & label', function () {
+      const parsedUri = plugin.parseUri(
+        fixture['parseUri']['ripple.com uri address with amount & label'][0]
+      )
+      assert.equal(
+        parsedUri.publicAddress,
+        fixture['parseUri']['ripple.com uri address with amount & label'][1]
+      )
+      assert.equal(
+        parsedUri.nativeAmount,
+        fixture['parseUri']['ripple.com uri address with amount & label'][2]
+      )
+      assert.equal(
+        parsedUri.currencyCode,
+        fixture['parseUri']['ripple.com uri address with amount & label'][3]
+      )
+      assert.equal(
+        parsedUri.metadata.name,
+        fixture['parseUri']['ripple.com uri address with amount & label'][4]
+      )
+    })
+    it('ripple.com uri address with amount, label & message', function () {
+      const parsedUri = plugin.parseUri(
+        fixture['parseUri']['ripple.com uri address with amount & label'][0]
+      )
+      assert.equal(
+        parsedUri.publicAddress,
+        fixture['parseUri']['ripple.com uri address with amount & label'][1]
+      )
+      assert.equal(
+        parsedUri.nativeAmount,
+        fixture['parseUri']['ripple.com uri address with amount & label'][2]
+      )
+      assert.equal(
+        parsedUri.currencyCode,
+        fixture['parseUri']['ripple.com uri address with amount & label'][3]
+      )
+      assert.equal(
+        parsedUri.metadata.name,
+        fixture['parseUri']['ripple.com uri address with amount & label'][4]
+      )
+      assert.equal(
+        parsedUri.metadata.message,
+        fixture['parseUri']['ripple.com uri address with amount & label'][5]
+      )
+    })
+    it('ripple.com uri address with unsupported param', function () {
+      const parsedUri = plugin.parseUri(
+        fixture['parseUri']['ripple.com uri address with amount & label'][0]
+      )
+      assert.equal(
+        parsedUri.publicAddress,
+        fixture['parseUri']['ripple.com uri address with amount & label'][1]
+      )
+      assert.equal(
+        parsedUri.nativeAmount,
+        fixture['parseUri']['ripple.com uri address with amount & label'][2]
+      )
+      assert.equal(
+        parsedUri.currencyCode,
+        fixture['parseUri']['ripple.com uri address with amount & label'][3]
+      )
+    })
   })
 
   describe(`encodeUri for Wallet type ${WALLET_TYPE}`, function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3348,6 +3348,10 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+querystringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
+
 quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
@@ -3563,6 +3567,10 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
 reserved-words@^0.1.2:
   version "0.1.2"
@@ -4312,6 +4320,13 @@ uri-js@^3.0.2:
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+
+url-parse@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.1.tgz#4dec9dad3dc8585f862fed461d2e19bbf623df30"
+  dependencies:
+    querystringify "^2.0.0"
+    requires-port "^1.0.0"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
Change to using url-parse library to more easily obtain query object.