### PR TITLE
Change NoAmountSpecified to function

### DIFF
--- a/src/currencyEngineXRP.js
+++ b/src/currencyEngineXRP.js
@@ -749,7 +749,7 @@ class RippleEngine {
     }
 
     if (bns.eq(nativeAmount, '0')) {
-      throw (new Error('ErrorNoAmountSpecified'))
+      throw (new error.NoAmountSpecifiedError())
     }
 
     const nativeBalance = this.walletLocalData.totalBalances[currencyCode]


### PR DESCRIPTION
The purpose of this task is to have the Ripple plugin throw the new `noAmountSpecifiedError` rather than a regular error with a string, and therefore let the GUI catch the error and hide it when the user first goes to the `SendConfirmation` scene  

https://app.asana.com/0/361770107085503/736453047132716/f

Connected PR's:
https://github.com/Airbitz/edge-react-gui/pull/715
https://github.com/Airbitz/edge-currency-monero/pull/3