### PR TITLE
Suggestion to replace ripplecharts with bithomp.

### DIFF
--- a/src/currencyInfoXRP.js
+++ b/src/currencyInfoXRP.js
@@ -25,8 +25,8 @@ export const currencyInfo: EdgeCurrencyInfo = {
 
   defaultSettings,
 
-  addressExplorer: 'https://xrpcharts.ripple.com/#/transactions/%s',
-  transactionExplorer: 'https://xrpcharts.ripple.com/#/transactions/%s',
+  addressExplorer: 'https://bithomp.com/explorer/%s',
+  transactionExplorer: 'https://bithomp.com/explorer/%s',
 
   denominations: [
     // An array of Objects of the possible denominations for this currency


### PR DESCRIPTION
Ledger Live uses Bithomp for exploring XRP. Many others too, it's much more user-friendly than ripple charts.
It's also one of the oldest, operates since 2015.